### PR TITLE
Add PHP authentication API and integrate frontend

### DIFF
--- a/account.html
+++ b/account.html
@@ -69,6 +69,7 @@
                             </div>
                             <button type="submit" class="button w-full" data-translate="auth_login_btn">Se connecter</button>
                         </form>
+                        <p id="login-message" class="mt-2 text-red-500"></p>
                         <p class="mt-4 text-text-300" data-translate="auth_register_prompt">Pas encore de compte ? <a href="#" id="show-register" class="text-brand-green-400 font-bold">Créer un compte</a></p>
                     </div>
 
@@ -83,6 +84,7 @@
                             </div>
                             <button type="submit" class="button w-full" data-translate="auth_register_btn">Créer le compte</button>
                         </form>
+                        <p id="register-message" class="mt-2 text-red-500"></p>
                         <p class="mt-4 text-text-300" data-translate="auth_login_prompt">Déjà un compte ? <a href="#" id="show-login" class="text-brand-blue-500 font-bold">Se connecter</a></p>
                     </div>
 

--- a/server/auth.php
+++ b/server/auth.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+$config = require __DIR__ . '/config.php';
+
+try {
+    $pdo = new PDO(
+        "mysql:host={$config['host']};dbname={$config['dbname']};charset=utf8mb4",
+        $config['user'],
+        $config['password'],
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database connection failed']);
+    exit;
+}
+
+$action = $_GET['action'] ?? '';
+
+// Helper to read JSON body
+$input = json_decode(file_get_contents('php://input'), true) ?? [];
+$username = $input['username'] ?? '';
+$password = $input['password'] ?? '';
+
+switch ($action) {
+    case 'register':
+        if (!$username || !$password) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'message' => 'Missing fields']);
+            break;
+        }
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        if ($stmt->fetch()) {
+            echo json_encode(['success' => false, 'message' => 'Username already exists']);
+            break;
+        }
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)');
+        $stmt->execute([$username, $hash]);
+        echo json_encode(['success' => true]);
+        break;
+
+    case 'login':
+        if (!$username || !$password) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'message' => 'Missing fields']);
+            break;
+        }
+        $stmt = $pdo->prepare('SELECT id, password_hash FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($user && password_verify($password, $user['password_hash'])) {
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['username'] = $username;
+            echo json_encode(['success' => true, 'username' => $username]);
+        } else {
+            echo json_encode(['success' => false, 'message' => 'Invalid credentials']);
+        }
+        break;
+
+    case 'check':
+        if (isset($_SESSION['username'])) {
+            echo json_encode(['loggedIn' => true, 'username' => $_SESSION['username']]);
+        } else {
+            echo json_encode(['loggedIn' => false]);
+        }
+        break;
+
+    case 'logout':
+        session_destroy();
+        echo json_encode(['success' => true]);
+        break;
+
+    default:
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Invalid action']);
+}

--- a/server/config.php
+++ b/server/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'host' => 'localhost',
+    'dbname' => 'my_database',
+    'user' => 'my_user',
+    'password' => 'my_password',
+];


### PR DESCRIPTION
## Summary
- Implement PHP auth API with register, login, session check, and logout
- Add MySQL config file
- Update account page and script to use fetch requests instead of localStorage for credentials

## Testing
- `php -l server/auth.php`
- `php -l server/config.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b78068326c833084179198c50e03aa