### PR TITLE
Read DB credentials from environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server/config.php

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # website
+
+## Configuration
+
+This project reads database connection details from environment variables:
+
+- `DB_HOST` – Database host
+- `DB_NAME` – Database name
+- `DB_USER` – Database user
+- `DB_PASSWORD` – Database password
+
+Ensure these are set in your environment before running the application.

--- a/server/config.php
+++ b/server/config.php
@@ -1,7 +1,7 @@
 <?php
 return [
-    'host' => 'localhost',
-    'dbname' => 'my_database',
-    'user' => 'my_user',
-    'password' => 'my_password',
+    'host' => getenv('DB_HOST') ?: '',
+    'dbname' => getenv('DB_NAME') ?: '',
+    'user' => getenv('DB_USER') ?: '',
+    'password' => getenv('DB_PASSWORD') ?: '',
 ];


### PR DESCRIPTION
## Summary
- load database credentials from environment variables in `server/config.php`
- document required environment variables in README
- ignore `server/config.php`

## Testing
- `php -l server/config.php`
- `php -l server/auth.php`


------
https://chatgpt.com/codex/tasks/task_b_68b784874c608330ae413f1562d698bc