### PR TITLE
Add backend contact form handling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -62,7 +62,7 @@
                     <p class="text-center text-text-300 mb-8" data-translate="contact_intro">
                         Une question ? Un projet ? N'hésitez pas à nous contacter. Notre équipe est prête à vous aider à franchir le pas vers l'agriculture intelligente.
                     </p>
-                    <form id="contact-form">
+                    <form id="contact-form" action="/server/contact.php" method="POST">
                         <div class="mb-6">
                             <label for="name" class="block mb-2 text-sm font-medium text-text-300" data-translate="contact_name">Nom</label>
                             <input type="text" id="name" class="form-input" placeholder="Votre nom complet" required>

--- a/script.js
+++ b/script.js
@@ -649,6 +649,26 @@ document.addEventListener('DOMContentLoaded', () => {
         checkAuth();
     }
 
+    // Gère la soumission du formulaire de contact
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+        contactForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const formData = new FormData(contactForm);
+            fetch('/server/contact.php', {
+                method: 'POST',
+                body: formData
+            })
+            .then(res => res.json())
+            .then(data => {
+                alert(data.message || (data.success ? 'Message envoyé avec succès!' : 'Une erreur est survenue.'));
+                if (data.success) contactForm.reset();
+            })
+            .catch(() => {
+                alert('Erreur réseau.');
+            });
+        });
+    }
 
     const savedLang = localStorage.getItem('language') || 'fr';
     if (languageSwitcher) languageSwitcher.value = savedLang;

--- a/server/contact.php
+++ b/server/contact.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: application/json');
+
+$name = trim($_POST['name'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$phone = trim($_POST['phone'] ?? '');
+$message = trim($_POST['message'] ?? '');
+
+if (!$name || !$email || !$message || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Champs invalides ou manquants.']);
+    exit;
+}
+
+$to = 'contact@farmlink.tn';
+$subject = 'Nouveau message de contact';
+$body = "Nom: $name\nEmail: $email\nTéléphone: $phone\nMessage:\n$message";
+$headers = "From: $email\r\nReply-To: $email\r\n";
+
+if (mail($to, $subject, $body, $headers)) {
+    echo json_encode(['success' => true, 'message' => 'Message envoyé avec succès.']);
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => "Échec de l'envoi du message."]);
+}
+?>


### PR DESCRIPTION
## Summary
- Send contact form submissions to `/server/contact.php` and display response alerts
- Implement PHP endpoint to validate input and forward messages to contact@farmlink.tn

## Testing
- `php -l server/contact.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b8f4cd30ec833098d9414e4dd0b818