### PR TITLE
Secure contact form email headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 server/config.php
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^6.9"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,100 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "baf0b1b659e688a64051c5ee9742a77e",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-24T15:19:31+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/server/contact.php
+++ b/server/contact.php
@@ -1,6 +1,11 @@
 <?php
 header('Content-Type: application/json');
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
 $name = trim($_POST['name'] ?? '');
 $email = trim($_POST['email'] ?? '');
 $phone = trim($_POST['phone'] ?? '');
@@ -12,15 +17,36 @@ if (!$name || !$email || !$message || !filter_var($email, FILTER_VALIDATE_EMAIL)
     exit;
 }
 
+// Reject potential header injection
+if (preg_match('/[\r\n]/', $email)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Email invalide.']);
+    exit;
+}
+
+$cleanEmail = filter_var($email, FILTER_SANITIZE_EMAIL);
 $to = 'contact@farmlink.tn';
 $subject = 'Nouveau message de contact';
-$body = "Nom: $name\nEmail: $email\nTéléphone: $phone\nMessage:\n$message";
-$headers = "From: $email\r\nReply-To: $email\r\n";
+$body = "Nom: $name\nEmail: $cleanEmail\nTéléphone: $phone\nMessage:\n$message";
 
-if (mail($to, $subject, $body, $headers)) {
-    echo json_encode(['success' => true, 'message' => 'Message envoyé avec succès.']);
-} else {
+$mail = new PHPMailer(true); // PHPMailer helps prevent header injection
+
+try {
+    $mail->setFrom('noreply@farmlink.tn', 'FarmLink');
+    $mail->addAddress($to);
+    $mail->addReplyTo($cleanEmail);
+
+    $mail->Subject = $subject;
+    $mail->Body    = $body;
+
+    if ($mail->send()) {
+        echo json_encode(['success' => true, 'message' => 'Message envoyé avec succès.']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'message' => "Échec de l'envoi du message."]);
+    }
+} catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['success' => false, 'message' => "Échec de l'envoi du message."]);
+    echo json_encode(['success' => false, 'message' => 'Erreur lors de l\'envoi du message.']);
 }
 ?>


### PR DESCRIPTION
## Summary
- validate contact form email to block header injection
- send mail through PHPMailer using a fixed `noreply@farmlink.tn` sender and sanitized `Reply-To`
- add Composer configuration for PHPMailer

## Testing
- `php -l server/contact.php`
- `composer install --no-interaction`


------
https://chatgpt.com/codex/tasks/task_b_68b90cbe47808330afae5980a4982d5c