### PR TITLE
Enforce HTTP method checks for auth actions

### DIFF
--- a/script.js
+++ b/script.js
@@ -626,7 +626,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
-        fetch('/server/auth.php?action=check')
+        fetch('/server/auth.php?action=check', { method: 'GET' })
             .then(res => res.json())
             .then(data => {
                 if (data.loggedIn) {
@@ -637,7 +637,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
     }
-=======
 
         // Gère la soumission du formulaire d'ajout de produit
         if (addProductForm) addProductForm.addEventListener('submit', (e) => {

--- a/server/auth.php
+++ b/server/auth.php
@@ -18,6 +18,7 @@ try {
 }
 
 $action = $_GET['action'] ?? '';
+$method = $_SERVER['REQUEST_METHOD'] ?? '';
 
 // Helper to read JSON body
 $input = json_decode(file_get_contents('php://input'), true) ?? [];
@@ -31,6 +32,11 @@ $region = trim($input['region'] ?? '');
 
 switch ($action) {
     case 'register':
+        if ($method !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['success' => false, 'message' => 'Method Not Allowed']);
+            break;
+        }
         if (!$username || !$password || !$lastName || !$firstName || !$email || !$phone || !$region) {
             http_response_code(400);
             echo json_encode(['success' => false, 'message' => 'Missing fields']);
@@ -55,6 +61,11 @@ switch ($action) {
         break;
 
     case 'login':
+        if ($method !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['success' => false, 'message' => 'Method Not Allowed']);
+            break;
+        }
         if (!$username || !$password) {
             http_response_code(400);
             echo json_encode(['success' => false, 'message' => 'Missing fields']);
@@ -73,6 +84,11 @@ switch ($action) {
         break;
 
     case 'check':
+        if ($method !== 'GET') {
+            http_response_code(405);
+            echo json_encode(['success' => false, 'message' => 'Method Not Allowed']);
+            break;
+        }
         if (isset($_SESSION['username'])) {
             echo json_encode(['loggedIn' => true, 'username' => $_SESSION['username']]);
         } else {
@@ -81,6 +97,11 @@ switch ($action) {
         break;
 
     case 'logout':
+        if ($method !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['success' => false, 'message' => 'Method Not Allowed']);
+            break;
+        }
         session_destroy();
         echo json_encode(['success' => true]);
         break;


### PR DESCRIPTION
## Summary
- ensure each auth endpoint validates the request method and returns 405 for mismatches
- explicitly use GET when checking login status on the frontend

## Testing
- `php -l server/auth.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b90cc28c108330b6b27a0442910e28