### PR TITLE
Add CSRF protection across PHP endpoints

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -63,6 +63,7 @@
                         Une question ? Un projet ? N'hésitez pas à nous contacter. Notre équipe est prête à vous aider à franchir le pas vers l'agriculture intelligente.
                     </p>
                     <form id="contact-form" action="/server/contact.php" method="POST">
+                        <input type="hidden" name="csrf_token" id="contact-csrf-token">
                         <div class="mb-6">
                             <label for="name" class="block mb-2 text-sm font-medium text-text-300" data-translate="contact_name">Nom</label>
                             <input type="text" id="name" class="form-input" placeholder="Votre nom complet" required>

--- a/server/contact.php
+++ b/server/contact.php
@@ -1,5 +1,21 @@
 <?php
+session_start();
 header('Content-Type: application/json');
+
+// Ensure CSRF token exists
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+// Validate CSRF token on POST requests
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_POST['csrf_token'] ?? '');
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    if (!$token || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        exit;
+    }
+}
 
 $name = trim($_POST['name'] ?? '');
 $email = trim($_POST['email'] ?? '');

--- a/server/products.php
+++ b/server/products.php
@@ -2,10 +2,25 @@
 session_start();
 header('Content-Type: application/json');
 
+// Ensure CSRF token exists
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
     echo json_encode(['success' => false, 'message' => 'Not authenticated']);
     exit;
+}
+
+// Validate CSRF token on non-GET requests
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+    if (!$token || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        exit;
+    }
 }
 
 $config = require __DIR__ . '/config.php';

--- a/server/user.php
+++ b/server/user.php
@@ -2,6 +2,21 @@
 session_start();
 header('Content-Type: application/json');
 
+// Ensure a CSRF token exists for this session
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+// Validate CSRF token on non-GET requests
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+    if (!$token || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        exit;
+    }
+}
+
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
     echo json_encode(['success' => false, 'message' => 'Unauthorized']);


### PR DESCRIPTION
## Summary
- generate and validate session-based CSRF tokens for auth, user, product, and contact endpoints
- expose CSRF token to clients and require it on all non-GET requests
- attach CSRF token to client fetch calls and contact form submissions

## Testing
- `php -l server/auth.php`
- `php -l server/user.php`
- `php -l server/products.php`
- `php -l server/contact.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b90cba7d30833081e5046252856678