### PR TITLE
feat: add model selection for AI advisor

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -84,7 +84,12 @@
                         </button>
                         
                         <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
-                        
+
+                        <select id="provider-select" class="form-input ml-2">
+                            <option value="chatgpt">ChatGPT</option>
+                            <option value="gemini">Gemini</option>
+                        </select>
+
                         <button type="submit" class="button">
                             <i class="fas fa-paper-plane"></i>
                         </button>


### PR DESCRIPTION
## Summary
- let users choose ChatGPT or Gemini for AI analysis
- fetch server-side AI responses and show loading spinner

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9123580f4833092dac11ec77f8926