### PR TITLE
Align AI provider identifiers with backend

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -86,8 +86,8 @@
                         <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
 
                         <select id="provider-select" class="form-input ml-2">
-                            <option value="chatgpt">ChatGPT</option>
-                            <option value="gemini">Gemini</option>
+                            <option value="openai">ChatGPT</option>
+                            <option value="anthropic">Claude</option>
                         </select>
 
                         <button type="submit" class="button">

--- a/script.js
+++ b/script.js
@@ -414,7 +414,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         async function handleTextAnalysis(question) {
             if (!question.trim()) return;
-            const provider = providerSelect ? providerSelect.value : '';
+            const provider = providerSelect?.value || '';
             showSpinner(true);
             aiResponseText.textContent = '';
             imagePreviewWrapper.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Use backend identifiers `openai` and `anthropic` for AI provider selection
- Forward selected provider value directly when submitting analysis requests

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68b9173d7a588330a67d6fe38a076ce3