### PR TITLE
Refactor AI provider handling

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -86,8 +86,8 @@
                         <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
 
                         <select id="provider-select" class="form-input ml-2">
-                            <option value="chatgpt">ChatGPT</option>
-                            <option value="gemini">Gemini</option>
+                            <option value="openai">OpenAI</option>
+                            <option value="anthropic">Anthropic</option>
                         </select>
 
                         <button type="submit" class="button">

--- a/script.js
+++ b/script.js
@@ -423,7 +423,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const response = await fetch('/server/ai.php', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ question, provider })
+                    body: JSON.stringify({ prompt: question, provider })
                 });
                 const data = await response.json();
                 if (data && data.answer) {

--- a/server/ai.php
+++ b/server/ai.php
@@ -1,14 +1,11 @@
 <?php
-
-// server/ai.php
-// Attempts a call to the requested AI provider and falls back to the other on error.
-// The name of the provider actually used is returned in the JSON response.
-
 header('Content-Type: application/json');
 
 $input = json_decode(file_get_contents('php://input'), true) ?? [];
 $prompt = $input['prompt'] ?? '';
 $requested = $input['provider'] ?? 'openai';
+
+$providers = ['openai', 'anthropic'];
 
 if (!$prompt) {
     http_response_code(400);
@@ -16,22 +13,32 @@ if (!$prompt) {
     exit;
 }
 
-$providers = ['openai', 'anthropic'];
-$other = $requested === $providers[0] ? $providers[1] : $providers[0];
+if (!in_array($requested, $providers, true)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Invalid provider']);
+    exit;
+}
 
 $used = $requested;
 $result = call_provider($used, $prompt);
+
 if ($result['error']) {
+    $other = $used === $providers[0] ? $providers[1] : $providers[0];
     $used = $other;
     $result = call_provider($used, $prompt);
+
     if ($result['error']) {
         http_response_code(502);
-        echo json_encode(['success' => false, 'provider' => $used, 'message' => $result['message'] ?? 'Both providers failed']);
+        echo json_encode(['success' => false, 'message' => $result['message'] ?? 'Both providers failed']);
         exit;
     }
 }
 
-echo json_encode(['success' => true, 'provider' => $used, 'data' => $result['data'] ?? null]);
+echo json_encode([
+    'success' => true,
+    'provider' => $used,
+    'answer'   => $result['answer'] ?? ''
+]);
 
 function call_provider(string $provider, string $prompt): array {
     $apiKey = getenv(strtoupper($provider) . '_API_KEY');
@@ -88,103 +95,16 @@ function call_provider(string $provider, string $prompt): array {
     }
 
     $data = json_decode($response, true);
-    return ['error' => false, 'data' => $data];
-}
-=======
-header('Content-Type: application/json');
-
-$provider = $_GET['provider'] ?? $_POST['provider'] ?? '';
-$prompt   = $_GET['prompt'] ?? $_POST['prompt'] ?? '';
-
-if (!$provider || !$prompt) {
-    http_response_code(400);
-    echo json_encode(['error' => ['message' => 'Paramètres provider et prompt requis.']]);
-    exit;
-}
-
-try {
-    switch ($provider) {
-        case 'chatgpt':
-            $apiKey = $_ENV['OPENAI_API_KEY'] ?? '';
-            if (!$apiKey) {
-                http_response_code(500);
-                echo json_encode(['error' => ['message' => 'Clé API OpenAI manquante.']]);
-                exit;
-            }
-
-            $url  = 'https://api.openai.com/v1/chat/completions';
-            $data = [
-                'model' => 'gpt-4o-mini',
-                'messages' => [
-                    ['role' => 'user', 'content' => $prompt]
-                ]
-            ];
-
-            $ch = curl_init($url);
-            curl_setopt_array($ch, [
-                CURLOPT_POST => true,
-                CURLOPT_HTTPHEADER => [
-                    'Content-Type: application/json',
-                    'Authorization: Bearer ' . $apiKey,
-                ],
-                CURLOPT_POSTFIELDS => json_encode($data),
-                CURLOPT_RETURNTRANSFER => true,
-            ]);
-            break;
-
-        case 'gemini':
-            $apiKey = $_ENV['GEMINI_API_KEY'] ?? '';
-            if (!$apiKey) {
-                http_response_code(500);
-                echo json_encode(['error' => ['message' => 'Clé API Gemini manquante.']]);
-                exit;
-            }
-
-            $url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' . urlencode($apiKey);
-            $data = [
-                'contents' => [
-                    [
-                        'parts' => [
-                            ['text' => $prompt]
-                        ]
-                    ]
-                ]
-            ];
-
-            $ch = curl_init($url);
-            curl_setopt_array($ch, [
-                CURLOPT_POST => true,
-                CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
-                CURLOPT_POSTFIELDS => json_encode($data),
-                CURLOPT_RETURNTRANSFER => true,
-            ]);
-            break;
-
-        default:
-            http_response_code(400);
-            echo json_encode(['error' => ['message' => 'Provider invalide.']]);
-            exit;
+    if (!is_array($data)) {
+        return ['error' => true, 'message' => 'Invalid response'];
     }
 
-    $response = curl_exec($ch);
-    if ($response === false) {
-        throw new Exception(curl_error($ch));
+    if ($provider === 'openai') {
+        $answer = $data['choices'][0]['message']['content'] ?? '';
+    } else {
+        $answer = $data['content'][0]['text'] ?? '';
     }
 
-    $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-
-    if ($statusCode >= 400) {
-        http_response_code($statusCode);
-        echo json_encode(['error' => ['message' => 'Erreur API', 'details' => $response]]);
-        exit;
-    }
-
-    http_response_code($statusCode);
-    echo $response;
-} catch (Exception $e) {
-    http_response_code(500);
-    echo json_encode(['error' => ['message' => $e->getMessage()]]);
+    return ['error' => false, 'answer' => $answer];
 }
 ?>
-


### PR DESCRIPTION
## Summary
- Send `prompt` and selected provider from the frontend
- Replace provider dropdown with OpenAI/Anthropic options
- Clean up backend AI proxy to support OpenAI and Anthropic with generic errors

## Testing
- `php -l server/ai.php`
- `node --check script.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_b_68b9173c6e448330998abc3780f6c9db