### PR TITLE
Remove duplicate AI advisor inputs

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -96,22 +96,6 @@
                         </button>
                     </form>
 
-                        <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
-
-                        <select id="provider-select" class="form-input ml-2">
-
-                            <option value="openai">ChatGPT</option>
-                            <option value="anthropic">Claude</option>
-                          
-                            <option value="openai">Modèle 1</option>
-                            <option value="anthropic">Modèle 2</option>
-
-                        </select>
-
-                        <button type="submit" class="button">
-                            <i class="fas fa-paper-plane"></i>
-                        </button>
-                    </form>
 
                      <p class="text-sm mt-4 text-text-500" data-translate="privacyNote">Confidentialité garantie : Toute l'analyse est effectuée sur votre appareil.</p>
                 </div>


### PR DESCRIPTION
## Summary
- remove second textarea and provider select from ai-advisor form to avoid duplicate controls
- ensure AI advisor script still references the single remaining text input and provider select

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68b91c22ca808330a01e59fb56c2e31b