### PR TITLE
Expand AI advisor textarea

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -84,7 +84,7 @@
                         </button>
                         
 
-                        <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
+                        <textarea id="text-input" class="form-input flex-grow" rows="4" placeholder="Posez votre question ici..."></textarea>
 
                         <select id="provider-select" class="form-input ml-2">
                             <option value="openai">OpenAI</option>

--- a/style.css
+++ b/style.css
@@ -375,7 +375,7 @@ body:not(.dark) .testimonial-card {
 }
 .ai-input-form textarea {
   background: transparent; border: none; resize: none;
-  color: var(--text-100); padding: .5rem; height: 40px; flex: 1;
+  color: var(--text-100); padding: .5rem; flex: 1; min-height: 120px;
 }
 .ai-input-form textarea:focus { outline: none; }
 .ai-action-button {


### PR DESCRIPTION
## Summary
- enlarge AI input field by removing fixed height and adding larger min-height
- give AI advisor textarea a default 4-row size

## Testing
- `composer validate`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b91f3f882c833093b518416552a738