### PR TITLE
Use server-side default AI provider

### DIFF
--- a/ai-advisor.html
+++ b/ai-advisor.html
@@ -86,11 +86,6 @@
 
                         <textarea id="text-input" class="form-input flex-grow" rows="1" placeholder="Posez votre question ici..."></textarea>
 
-                        <select id="provider-select" class="form-input ml-2">
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic</option>
-                        </select>
-
                         <button type="submit" class="button">
                             <i class="fas fa-paper-plane"></i>
                         </button>

--- a/script.js
+++ b/script.js
@@ -375,7 +375,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const cam = document.getElementById('cam');
         const aiResponseText = document.getElementById('ai-response-text');
         const aiSpinner = document.getElementById('ai-spinner');
-        const providerSelect = document.getElementById('provider-select');
 
         const progressContainer = document.getElementById('progress-container');
         const progressBar = document.getElementById('progressBar');
@@ -414,7 +413,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         async function handleTextAnalysis(question) {
             if (!question.trim()) return;
-            const provider = providerSelect?.value || '';
             showSpinner(true);
             aiResponseText.textContent = '';
             imagePreviewWrapper.classList.add('hidden');
@@ -423,7 +421,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const response = await fetch('/server/ai.php', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ prompt: question, provider })
+                    body: JSON.stringify({ prompt: question })
                 });
                 const data = await response.json();
                 if (data && data.answer) {


### PR DESCRIPTION
## Summary
- remove provider drop-down from AI advisor page
- simplify front-end script to always send only prompt so server picks provider

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_b_68b91f3ef76883308e86478d633b41cb