### PR TITLE
Consolidate auth check to single csrfFetch request

### DIFF
--- a/script.js
+++ b/script.js
@@ -640,10 +640,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
-        csrfFetch('/server/auth.php?action=check')
-
-        fetch('/server/auth.php?action=check', { method: 'GET' })
-
+        csrfFetch('/server/auth.php?action=check', { method: 'GET' })
             .then(res => res.json())
             .then(data => {
                 csrfToken = data.csrfToken;


### PR DESCRIPTION
## Summary
- Remove redundant auth check request
- Use `csrfFetch` with `.then` chain to handle login state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b92b93afdc8330b1fa6a84184a33f0