### PR TITLE
Fix footer order around testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,8 +141,8 @@
                         </div>
                     </div>
                 </div>
+            </section>
         </footer>
-    </section>    
     </main>
     <footer class="text-center py-8 border-t border-border-soft">
         <p data-translate="footer_copyright">&copy; 2025 FarmLink. Tous droits réservés.</p>


### PR DESCRIPTION
## Summary
- ensure testimonials section closes before its wrapping footer for proper nesting

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_b_68b92b91cc7083309dbdf2c011f2c740