### PR TITLE
Reject overlong AI prompts

### DIFF
--- a/server/ai.php
+++ b/server/ai.php
@@ -2,7 +2,7 @@
 header('Content-Type: application/json');
 
 $input = json_decode(file_get_contents('php://input'), true) ?? [];
-$prompt = $input['prompt'] ?? '';
+$prompt = strip_tags($input['prompt'] ?? '');
 $requested = $input['provider'] ?? 'openai';
 
 $providers = ['openai', 'anthropic'];
@@ -10,6 +10,12 @@ $providers = ['openai', 'anthropic'];
 if (!$prompt) {
     http_response_code(400);
     echo json_encode(['success' => false, 'message' => 'Missing prompt']);
+    exit;
+}
+
+if (mb_strlen($prompt) > 1000) {
+    http_response_code(413);
+    echo json_encode(['success' => false, 'message' => 'Prompt too long']);
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Strip HTML tags from incoming AI prompts
- Reject prompts exceeding 1000 characters with HTTP 413

## Testing
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"prompt":"hello"}' http://127.0.0.1:8000/server/ai.php`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"prompt":"'$LONG'"}' http://127.0.0.1:8000/server/ai.php`

------
https://chatgpt.com/codex/tasks/task_b_68b92b9681cc8330b92a7ea7bf5c65e8