### PR TITLE
Harden PHP session handling

### DIFF
--- a/server/auth.php
+++ b/server/auth.php
@@ -1,4 +1,9 @@
 <?php
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => true,
+    'samesite' => 'Strict',
+]);
 session_start();
 header('Content-Type: application/json');
 
@@ -90,6 +95,7 @@ switch ($action) {
         $stmt->execute([$username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password_hash'])) {
+            session_regenerate_id(true);
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $username;
             echo json_encode(['success' => true, 'username' => $username, 'csrfToken' => $_SESSION['csrf_token']]);


### PR DESCRIPTION
## Summary
- Harden session cookies with HttpOnly, Secure, and Strict SameSite flags
- Rotate session IDs on successful login

## Testing
- `curl -i http://127.0.0.1:8000/server/auth.php?action=check`
- `curl -i -b cookies.txt -X POST -H "Content-Type: application/json" -H "X-CSRF-Token: ffb1b44744731caa111464ffb70d581e7c341224059a040f1b367c2331025a01" -d '{"username":"foo","password":"bar"}' http://127.0.0.1:8000/server/auth.php?action=login` *(fails: Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b92b94d448833085d2cca6a0dfa3d4