### PR TITLE
Remove duplicate saved language initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -836,9 +836,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const savedLang = localStorage.getItem('language') || 'fr';
-    if (languageSwitcher) languageSwitcher.value = savedLang;
-    applyLanguage(savedLang);
     const savedTheme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     applyTheme(savedTheme);
     if (typeof AOS !== 'undefined') AOS.init({ duration: 800, once: true, offset: 50 });


### PR DESCRIPTION
## Summary
- Remove redundant savedLang re-declaration and applyLanguage call at end of script.js

## Testing
- `node --check script.js`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68b935313c2c8330b08bd02b01b4c180