### PR TITLE
Remove inline AOS initialization from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,12 +150,5 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="script.js"></script>
-    <script>
-        AOS.init({
-            duration: 800,
-            once: true,
-            offset: 50
-        });
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicate inline AOS initialization from homepage so script.js handles animations

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_b_68b93a43c98483308deb1093e01ca598