### PR TITLE
Apply saved theme on page load

### DIFF
--- a/script.js
+++ b/script.js
@@ -343,8 +343,10 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const savedLang = localStorage.getItem('language') || 'fr';
+    const savedTheme = localStorage.getItem('theme') || 'dark';
     if (languageSwitcher) languageSwitcher.value = savedLang;
     applyLanguage(savedLang);
+    applyTheme(savedTheme);
 
     const currentPage = window.location.pathname.split("/").pop() || "index.html";
     document.querySelectorAll('.nav-link').forEach(link => {
@@ -836,8 +838,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const savedTheme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    applyTheme(savedTheme);
     try {
         AOS.init({ duration: 800, once: true, offset: 50 });
     } catch (e) {


### PR DESCRIPTION
## Summary
- load theme preference from localStorage (default to dark) and apply it immediately alongside the saved language.
- verify index, about, and solutions pages include script.js so they use the updated script.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9434740b48330a2defd1913276a27