### PR TITLE
Set solutions page to dark theme by default

### DIFF
--- a/solutions.html
+++ b/solutions.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="aos.css">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="dark">
 
     <header class="sticky top-0 z-50 shadow-md">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">


### PR DESCRIPTION
## Summary
- default solutions page to dark mode for consistency

## Testing
- `node /tmp/theme_test/testTheme.js`


------
https://chatgpt.com/codex/tasks/task_b_68b943469c8c8330be1dcfb8a29de44b